### PR TITLE
make the template runnable and clean from useless options

### DIFF
--- a/initEnv.m
+++ b/initEnv.m
@@ -56,8 +56,8 @@ function initEnv
 
     if numel(dir(libDirectory)) <= 2 % Means that the external is empty
         error(['Git submodules are not cloned!', ...
-              'Try this in your terminal:', ...
-              ' git submodule update --recursive ']);
+               'Try this in your terminal:', ...
+               ' git submodule update --recursive ']);
     else
         addDependencies();
     end

--- a/mainScript.m
+++ b/mainScript.m
@@ -22,113 +22,112 @@ cfg = createFilename(cfg);
 
 % Safety loop: close the screen if code crashes
 try
-    
+
     %% Init the experiment
     [cfg] = initPTB(cfg);
-    
+
     cfg = postInitializationSetup(cfg);
-    
+
     [el] = eyeTracker('Calibration', cfg);
-    
+
     %     [cfg] = expDesign(cfg);
-    
+
     % Prepare for the output logfiles with all
     logFile.extraColumns = cfg.extraColumns;
     logFile = saveEventsFile('open', cfg, logFile);
-    
+
     disp(cfg);
-    
+
     % Show experiment instruction
     standByScreen(cfg);
-    
+
     % prepare the KbQueue to collect responses
     getResponse('init', cfg.keyboard.responseBox, cfg);
-    
+
     %% Experiment Start
-    
+
     eyeTracker('StartRecording', cfg);
-    
+
     cfg = getExperimentStart(cfg);
-    
+
     getResponse('start', cfg.keyboard.responseBox);
-    
-    
+
     %% For Each Block
-    
+
     for iBlock = 1:cfg.design.nbBlocks
-        
-        waitFor(cfg, cfg.timing.onsetDelay)
-    
-    for iTrial = 1:cfg.design.nbTrials
-        
-        fprintf('\n - Running trial %.0f \n', iTrial);
-        
-        % Check for experiment abortion from operator
-        checkAbort(cfg, cfg.keyboard.keyboard);
-        
-        [thisEvent, thisFixation, cfg] = preTrialSetup(cfg, iBlock, iTrial);
-       
-        % AVAILABLE IN A NEW RELEASE SOON
-        %
-        % eyeTracker('Message', cfg, ...
-        %     ['start_trial-', num2str(iTrial), '_', thisEvent.trial_type]);
-        
-        % play the dots and collect onset and duraton of the event
-        [onset, duration] = doTrial(cfg, thisEvent, thisFixation);
-        
-        thisEvent = preSaveSetup( ...
-            thisEvent, ...
-            iBlock, ...
-            iTrial, ...
-            duration, onset, ...
-            cfg, ...
-            logFile);
-        
-        saveEventsFile('save', cfg, thisEvent);
-        
-        % collect the responses and appends to the event structure for
-        % saving in the tsv file
-        responseEvents = getResponse('check', cfg.keyboard.responseBox, cfg);
-        
-        responseEvents(1).fileID = logFile.fileID;
-        responseEvents(1).extraColumns = logFile.extraColumns;
-        saveEventsFile('save', cfg, responseEvents);
-        
-        % AVAILABLE IN A NEW RELEASE SOON
-        %
-        % eyeTracker('Message', cfg, ...
-        %     ['end_trial-', num2str(iTrial), '_', thisEvent.trial_type]);
-        
-        waitFor(cfg, cfg.timing.ISI);
+
+        waitFor(cfg, cfg.timing.onsetDelay);
+
+        for iTrial = 1:cfg.design.nbTrials
+
+            fprintf('\n - Running trial %.0f \n', iTrial);
+
+            % Check for experiment abortion from operator
+            checkAbort(cfg, cfg.keyboard.keyboard);
+
+            [thisEvent, thisFixation, cfg] = preTrialSetup(cfg, iBlock, iTrial);
+
+            % AVAILABLE IN A NEW RELEASE SOON
+            %
+            % eyeTracker('Message', cfg, ...
+            %     ['start_trial-', num2str(iTrial), '_', thisEvent.trial_type]);
+
+            % play the dots and collect onset and duraton of the event
+            [onset, duration] = doTrial(cfg, thisEvent, thisFixation);
+
+            thisEvent = preSaveSetup( ...
+                                     thisEvent, ...
+                                     iBlock, ...
+                                     iTrial, ...
+                                     duration, onset, ...
+                                     cfg, ...
+                                     logFile);
+
+            saveEventsFile('save', cfg, thisEvent);
+
+            % collect the responses and appends to the event structure for
+            % saving in the tsv file
+            responseEvents = getResponse('check', cfg.keyboard.responseBox, cfg);
+
+            responseEvents(1).fileID = logFile.fileID;
+            responseEvents(1).extraColumns = logFile.extraColumns;
+            saveEventsFile('save', cfg, responseEvents);
+
+            % AVAILABLE IN A NEW RELEASE SOON
+            %
+            % eyeTracker('Message', cfg, ...
+            %     ['end_trial-', num2str(iTrial), '_', thisEvent.trial_type]);
+
+            waitFor(cfg, cfg.timing.ISI);
+
+        end
 
     end
-    
-    end
-    
+
     % End of the run for the BOLD to go down
     waitFor(cfg, cfg.timing.endDelay);
-    
+
     cfg = getExperimentEnd(cfg);
-    
+
     eyeTracker('StopRecordings', cfg);
-    
+
     % Close the logfiles
     saveEventsFile('close', cfg, logFile);
-    
+
     getResponse('stop', cfg.keyboard.responseBox);
     getResponse('release', cfg.keyboard.responseBox);
-    
+
     eyeTracker('Shutdown', cfg);
-    
+
     createJson(cfg, cfg);
-    
+
     farewellScreen(cfg);
-    
+
     cleanUp();
-    
+
 catch
-    
+
     cleanUp();
     psychrethrow(psychlasterror);
-    
+
 end

--- a/mainScript.m
+++ b/mainScript.m
@@ -55,6 +55,10 @@ try
     
     %% For Each Block
     
+    for iBlock = 1:cfg.design.nbBlocks
+        
+        waitFor(cfg, cfg.timing.onsetDelay)
+    
     for iTrial = 1:cfg.design.nbTrials
         
         fprintf('\n - Running trial %.0f \n', iTrial);
@@ -64,19 +68,22 @@ try
         
         [thisEvent, thisFixation, cfg] = preTrialSetup(cfg, iBlock, iTrial);
        
-        eyeTracker('Message', cfg, ...
-            ['start_trial-', num2str(iTrial), '_', thisEvent.trial_type]);
+        % AVAILABLE IN A NEW RELEASE SOON
+        %
+        % eyeTracker('Message', cfg, ...
+        %     ['start_trial-', num2str(iTrial), '_', thisEvent.trial_type]);
         
         % play the dots and collect onset and duraton of the event
         [onset, duration] = doTrial(cfg, thisEvent, thisFixation);
         
         thisEvent = preSaveSetup( ...
             thisEvent, ...
-            thisFixation, ...
+            iBlock, ...
             iTrial, ...
             duration, onset, ...
             cfg, ...
             logFile);
+        
         saveEventsFile('save', cfg, thisEvent);
         
         % collect the responses and appends to the event structure for
@@ -87,11 +94,15 @@ try
         responseEvents(1).extraColumns = logFile.extraColumns;
         saveEventsFile('save', cfg, responseEvents);
         
-        eyeTracker('Message', cfg, ...
-            ['end_trial-', num2str(iEvent), '_', thisEvent.trial_type]);
+        % AVAILABLE IN A NEW RELEASE SOON
+        %
+        % eyeTracker('Message', cfg, ...
+        %     ['end_trial-', num2str(iTrial), '_', thisEvent.trial_type]);
         
         waitFor(cfg, cfg.timing.ISI);
 
+    end
+    
     end
     
     % End of the run for the BOLD to go down

--- a/setParameters.m
+++ b/setParameters.m
@@ -44,7 +44,7 @@ function [cfg] = setParameters()
 
     cfg.design.blockNames = {'condition_1','condition_2'};
     
-    cfg.design.nbBlocks = 1;
+    cfg.design.nbBlocks = 2;
     cfg.design.nbTrials = 4;
 
     %% Timing

--- a/setParameters.m
+++ b/setParameters.m
@@ -42,22 +42,6 @@ function [cfg] = setParameters()
 
     %% Experiment Design
 
-    % switching this on to MT or MT/MST with use:
-    % - MT: translational motion on the whole screen
-    %   - alternates static and motion (left or right) blocks
-    % - MST: radial motion centered in a circle aperture that is on the opposite
-    % side of the screen relative to the fixation
-    %   - alternates fixaton left and fixation right
-    cfg.design.localizer = 'MT';
-    % cfg.design.localizer = 'MT_MST';
-
-    cfg.design.motionType = 'translation';
-    cfg.design.motionDirections = [0 0 180 180];
-    cfg.design.names = {'static'; 'motion'};
-
-    cfg.design.nbRepetitions = 8;
-    cfg.design.nbEventsPerBlock = 12; % DO NOT CHANGE
-    
     cfg.design.blockNames = {'condition_1','condition_2'};
     
     cfg.design.nbBlocks = 1;
@@ -71,16 +55,16 @@ function [cfg] = setParameters()
     % IBI
     % block length = (cfg.eventDuration + cfg.ISI) * cfg.design.nbEventsPerBlock
 
-    cfg.timing.eventDuration = 0.8; % second
+    cfg.timing.eventDuration = 2; % second
 
     % Time between blocs in secs
-    cfg.timing.IBI = 0;
+    cfg.timing.IBI = 2;
     % Time between events in secs
-    cfg.timing.ISI = 0;
+    cfg.timing.ISI = 1;
     % Number of seconds before the motion stimuli are presented
     cfg.timing.onsetDelay = 2;
     % Number of seconds after the end all the stimuli before ending the run
-    cfg.timing.endDelay = 3.6;
+    cfg.timing.endDelay = 2;
 
     % reexpress those in terms of repetition time
     if cfg.pacedByTriggers.do
@@ -101,30 +85,9 @@ function [cfg] = setParameters()
 
     end
 
-    %% Visual Stimulation
-
-    % Speed in visual angles / second
-    cfg.dot.speed = 1;
-    % Coherence Level (0-1)
-    cfg.dot.coherence = 1;
-    % Number of dots per visual angle square.
-    cfg.dot.density = 1;
-    % Dot life time in seconds
-    cfg.dot.lifeTime = Inf;
-    % proportion of dots killed per frame
-    cfg.dot.proportionKilledPerFrame = 0;
-    % Dot Size (dot width) in visual angles.
-    cfg.dot.size = .1;
-    cfg.dot.color = cfg.color.white;
-
-    % Diameter/length of side of aperture in Visual angles
-    cfg.aperture.type = 'none';
-    cfg.aperture.width = []; % if left empty it will take the screen height
-    cfg.aperture.xPos = 0;
-
     %% Task(s)
 
-    cfg.task.name = 'visual localizer';
+    cfg.task.name = 'template PTB experiment';
 
     % Instruction
     cfg.task.instruction = '1-Detect the RED fixation cross\n \n\n';
@@ -142,17 +105,10 @@ function [cfg] = setParameters()
     cfg.target.duration = 0.1; % In secs
 
     cfg.extraColumns = { ...
-                        'direction', ...
-                        'speedDegVA', ...
                         'target', ...
                         'event', ...
                         'block', ...
-                        'keyName', ...
-                        'fixationPosition', ...
-                        'aperturePosition'};
-
-    %% orverrireds the relevant fields in case we use the MT / MST localizer
-    cfg = setParametersMtMst(cfg);
+                        'keyName'};
 
 end
 
@@ -200,35 +156,6 @@ function cfg = setMonitor(cfg)
     if strcmpi(cfg.testingDevice, 'mri')
         cfg.screen.monitorWidth = 25;
         cfg.screen.monitorDistance = 95;
-    end
-
-end
-
-function cfg = setParametersMtMst(cfg)
-
-    if isfield(cfg.design, 'localizer') && strcmpi(cfg.design.localizer, 'MT_MST')
-
-        cfg.task.name = 'mt mst localizer';
-
-        cfg.design.motionType = 'radial';
-        cfg.design.motionDirections = [666 666 -666 -666];
-        cfg.design.names = {'fixation_right'; 'fixation_left'};
-        cfg.design.xDisplacementFixation = 7;
-        cfg.design.xDisplacementAperture = 3;
-
-        cfg.timing.IBI = 3.6;
-
-        % reexpress those in terms of repetition time
-        if cfg.pacedByTriggers.do
-
-            cfg.timing.IBI = 2;
-
-        end
-
-        cfg.aperture.type = 'circle';
-        cfg.aperture.width = 7; % if left empty it will take the screen height
-        cfg.aperture.xPos = cfg.design.xDisplacementAperture;
-
     end
 
 end

--- a/setParameters.m
+++ b/setParameters.m
@@ -2,7 +2,7 @@
 
 function [cfg] = setParameters()
 
-    % VISUAL LOCALIZER
+    % Template PTB experiment
 
     % Initialize the parameters and general configuration variables
     cfg = struct();
@@ -20,8 +20,10 @@ function [cfg] = setParameters()
     cfg.debug.smallWin = false; % To test on a part of the screen, change to 1
     cfg.debug.transpWin = true; % To test with trasparent full size screen
 
-    cfg.verbose = 1;
-
+    cfg.verbose = 0;
+    
+    cfg.skipSyncTests = 0;
+    
     %% Engine parameters
 
     cfg.testingDevice = 'mri';
@@ -55,6 +57,11 @@ function [cfg] = setParameters()
 
     cfg.design.nbRepetitions = 8;
     cfg.design.nbEventsPerBlock = 12; % DO NOT CHANGE
+    
+    cfg.design.blockNames = {'condition_1','condition_2'};
+    
+    cfg.design.nbBlocks = 1;
+    cfg.design.nbTrials = 4;
 
     %% Timing
 
@@ -71,7 +78,7 @@ function [cfg] = setParameters()
     % Time between events in secs
     cfg.timing.ISI = 0;
     % Number of seconds before the motion stimuli are presented
-    cfg.timing.onsetDelay = 0;
+    cfg.timing.onsetDelay = 2;
     % Number of seconds after the end all the stimuli before ending the run
     cfg.timing.endDelay = 3.6;
 

--- a/setParameters.m
+++ b/setParameters.m
@@ -21,9 +21,9 @@ function [cfg] = setParameters()
     cfg.debug.transpWin = true; % To test with trasparent full size screen
 
     cfg.verbose = 0;
-    
+
     cfg.skipSyncTests = 0;
-    
+
     %% Engine parameters
 
     cfg.testingDevice = 'mri';
@@ -42,8 +42,8 @@ function [cfg] = setParameters()
 
     %% Experiment Design
 
-    cfg.design.blockNames = {'condition_1','condition_2'};
-    
+    cfg.design.blockNames = {'condition_1', 'condition_2'};
+
     cfg.design.nbBlocks = 2;
     cfg.design.nbTrials = 4;
 

--- a/src/doTrial.m
+++ b/src/doTrial.m
@@ -1,0 +1,40 @@
+function [onset, duration] = doTrial(cfg, thisEvent, thisFixation)
+
+
+    %% Get parameters
+
+    % Set for how many frames this event will last
+    framesLeft = floor(cfg.timing.eventDuration / cfg.screen.ifi);
+
+    %% Start the dots presentation
+    vbl = Screen('Flip', cfg.screen.win);
+    onset = vbl;
+
+        while framesLeft
+
+        thisFixation.fixation.color = cfg.fixation.color;
+        if thisEvent.target(1) && vbl < (onset + cfg.target.duration)
+            thisFixation.fixation.color = cfg.fixation.colorTarget;
+        end
+        drawFixation(thisFixation);
+
+        Screen('DrawingFinished', cfg.screen.win);
+
+        vbl = Screen('Flip', cfg.screen.win, vbl + cfg.screen.ifi);
+
+        %% Update counters
+
+        % Check for end of loop
+        framesLeft = framesLeft - 1;
+        
+        end
+
+    %% Erase last dots
+
+    drawFixation(thisFixation);
+
+    Screen('DrawingFinished', cfg.screen.win);
+
+    vbl = Screen('Flip', cfg.screen.win, vbl + cfg.screen.ifi);
+
+    duration = vbl - onset;

--- a/src/doTrial.m
+++ b/src/doTrial.m
@@ -1,6 +1,5 @@
 function [onset, duration] = doTrial(cfg, thisEvent, thisFixation)
 
-
     %% Get parameters
 
     % Set for how many frames this event will last
@@ -10,7 +9,7 @@ function [onset, duration] = doTrial(cfg, thisEvent, thisFixation)
     vbl = Screen('Flip', cfg.screen.win);
     onset = vbl;
 
-        while framesLeft
+    while framesLeft
 
         thisFixation.fixation.color = cfg.fixation.color;
         if thisEvent.target(1) && vbl < (onset + cfg.target.duration)
@@ -26,8 +25,8 @@ function [onset, duration] = doTrial(cfg, thisEvent, thisFixation)
 
         % Check for end of loop
         framesLeft = framesLeft - 1;
-        
-        end
+
+    end
 
     %% Erase last dots
 

--- a/src/preSaveSetup.m
+++ b/src/preSaveSetup.m
@@ -5,9 +5,11 @@ function varargout = preSaveSetup(varargin)
 
     % generic function to prepare structures before saving
 
-    [thisEvent, duration, onset, cfg, logFile] = ...
+    [thisEvent, iBlock, iTrial, duration, onset, cfg, logFile] = ...
         deal(varargin{:});
 
+    thisEvent.event = iTrial;
+    thisEvent.block = iBlock;
     thisEvent.keyName = 'n/a';
     thisEvent.duration = duration;
     thisEvent.onset = onset - cfg.experimentStart;

--- a/src/preTrialSetup.m
+++ b/src/preTrialSetup.m
@@ -1,14 +1,20 @@
 % (C) Copyright 2020 CPP visual motion localizer developpers
 
-function preTrialSetup(varargin)
+function varargout = preTrialSetup(varargin)
     % varargout = postInitializatinSetup(varargin)
 
     % generic function to prepare some structure before each trial
 
-%     [cfg, iBlock, iEvent] = deal(varargin{:});
+    [cfg, iBlock, iEvent] = deal(varargin{:});
 
+    % set block name and if it is a target
+    thisEvent.trial_type = cfg.design.blockNames{iBlock};
+    thisEvent.target = randi([0, 1], [1, 1]);
 
+    % If this frame shows a target we change the color of the cross
+    thisFixation.fixation = cfg.fixation;
+    thisFixation.screen = cfg.screen;
 
-%     varargout = {thisEvent, thisFixation, cfg};
+    varargout = {thisEvent, thisFixation, cfg};
 
 end


### PR DESCRIPTION
I have add some code to make it display something (the fixation cross) and deleted the option from the localizers. I think that having a clean one (instead with the options from the localizer) is better, users can be sent to see the localizers repo to have a complex example on how to develop a full experiment.